### PR TITLE
feat: Dynamic CPU support, health/raft metrics, and additional improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ typesense-prometheus-exporter [OPTIONS] --typesense-host <TYPESENSE_HOST> --type
 - `--typesense-protocol <TYPESENSE_PROTOCOL>`: Typesense protocol (env: TYPESENSE_PROTOCOL, default: http).
 - `--typesense-api-key <TYPESENSE_API_KEY>`: Typesense API key (env: TYPESENSE_API_KEY).
 - `--typesense-port <TYPESENSE_PORT>`: Typesense port number (env: TYPESENSE_PORT, default: 8108).
+- `--typesense-timeout <TYPESENSE_TIMEOUT>`: Timeout for Typesense API requests in seconds (env: TYPESENSE_TIMEOUT, default: -1 to disable).
 - `--exporter-bind-address <EXPORTER_BIND_ADDRESS>`: Internal server bind address (env: EXPORTER_BIND_ADDRESS, default: 0.0.0.0).
 - `--exporter-bind-port <EXPORTER_BIND_PORT>`: Internal server bind port (env: EXPORTER_BIND_PORT, default: 8888).
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,4 +27,8 @@ pub struct CliArgs {
     /// Bind port for internal server
     #[arg(long, env, default_value_t = 8888)]
     pub(crate) exporter_bind_port: u16,
+
+    /// Timeout for Typesense API requests in seconds (-1 to disable)
+    #[arg(long, env, default_value_t = -1)]
+    pub(crate) typesense_timeout: i64,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use tokio;
 pub mod cli;
 pub mod prometheus_exp;
 pub mod server;

--- a/src/prometheus_exp.rs
+++ b/src/prometheus_exp.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 use crate::{
     cli::CliArgs,
     typesense::models::{
-        typesense_metrics_model::TypesenseMetrics, typesense_stats_model::TypesenseStats,
+        typesense_metrics_model::TypesenseMetrics,
+        typesense_stats_model::TypesenseStats,
+        typesense_health_model::TypesenseHealth,
+        typesense_debug_model::TypesenseDebug,
     },
 };
 use prometheus::{register_gauge_vec_with_registry, Encoder, Registry, TextEncoder};
@@ -13,6 +16,8 @@ use regex::Regex;
 pub(crate) async fn generate_metrics(
     ts_metrics: TypesenseMetrics,
     ts_stats: TypesenseStats,
+    ts_health: TypesenseHealth,
+    ts_debug: TypesenseDebug,
     cli_args: Arc<CliArgs>,
 ) -> String {
     let registry = Registry::new();
@@ -25,54 +30,18 @@ pub(crate) async fn generate_metrics(
     )
     .unwrap();
 
-    typesense_metrics
-        .with_label_values(&[
-            &cli_args.typesense_host,
-            &cli_args.typesense_port.to_string(),
-            "system_cpu1_active_percentage",
-        ])
-        .set(
-            ts_metrics
-                .system_cpu1_active_percentage
-                .parse()
-                .unwrap_or(0.0),
-        );
-    typesense_metrics
-        .with_label_values(&[
-            &cli_args.typesense_host,
-            &cli_args.typesense_port.to_string(),
-            "system_cpu3_active_percentage",
-        ])
-        .set(
-            ts_metrics
-                .system_cpu3_active_percentage
-                .parse()
-                .unwrap_or(0.0),
-        );
-    typesense_metrics
-        .with_label_values(&[
-            &cli_args.typesense_host,
-            &cli_args.typesense_port.to_string(),
-            "system_cpu2_active_percentage",
-        ])
-        .set(
-            ts_metrics
-                .system_cpu2_active_percentage
-                .parse()
-                .unwrap_or(0.0),
-        );
-    typesense_metrics
-        .with_label_values(&[
-            &cli_args.typesense_host,
-            &cli_args.typesense_port.to_string(),
-            "system_cpu4_active_percentage",
-        ])
-        .set(
-            ts_metrics
-                .system_cpu4_active_percentage
-                .parse()
-                .unwrap_or(0.0),
-        );
+    // Export all CPU percentage metrics dynamically
+    for (key, value) in ts_metrics.get_cpu_percentages() {
+        typesense_metrics
+            .with_label_values(&[
+                &cli_args.typesense_host,
+                &cli_args.typesense_port.to_string(),
+                &key,
+            ])
+            .set(value);
+    }
+
+    // Aggregate CPU percentage
     typesense_metrics
         .with_label_values(&[
             &cli_args.typesense_host,
@@ -85,6 +54,8 @@ pub(crate) async fn generate_metrics(
                 .parse()
                 .unwrap_or(0.0),
         );
+
+    // Disk metrics
     typesense_metrics
         .with_label_values(&[
             &cli_args.typesense_host,
@@ -99,6 +70,8 @@ pub(crate) async fn generate_metrics(
             "system_disk_used_bytes",
         ])
         .set(ts_metrics.system_disk_used_bytes.parse().unwrap_or(0.0));
+
+    // Memory metrics (including swap)
     typesense_metrics
         .with_label_values(&[
             &cli_args.typesense_host,
@@ -113,6 +86,22 @@ pub(crate) async fn generate_metrics(
             "system_memory_used_bytes",
         ])
         .set(ts_metrics.system_memory_used_bytes.parse().unwrap_or(0.0));
+    typesense_metrics
+        .with_label_values(&[
+            &cli_args.typesense_host,
+            &cli_args.typesense_port.to_string(),
+            "system_memory_total_swap_bytes",
+        ])
+        .set(ts_metrics.system_memory_total_swap_bytes.parse().unwrap_or(0.0));
+    typesense_metrics
+        .with_label_values(&[
+            &cli_args.typesense_host,
+            &cli_args.typesense_port.to_string(),
+            "system_memory_used_swap_bytes",
+        ])
+        .set(ts_metrics.system_memory_used_swap_bytes.parse().unwrap_or(0.0));
+
+    // Network metrics
     typesense_metrics
         .with_label_values(&[
             &cli_args.typesense_host,
@@ -132,6 +121,8 @@ pub(crate) async fn generate_metrics(
             "system_network_sent_bytes",
         ])
         .set(ts_metrics.system_network_sent_bytes.parse().unwrap_or(0.0));
+
+    // Typesense memory metrics
     typesense_metrics
         .with_label_values(&[
             &cli_args.typesense_host,
@@ -217,6 +208,7 @@ pub(crate) async fn generate_metrics(
                 .unwrap_or(0.0),
         );
 
+    // Stats metrics
     let typesense_stats = register_gauge_vec_with_registry!(
         "typesense_stats",
         "Data received through the stats api of typesense",
@@ -224,6 +216,15 @@ pub(crate) async fn generate_metrics(
         registry
     )
     .unwrap();
+
+    // Cache hit ratio (important for search performance monitoring)
+    typesense_stats
+        .with_label_values(&[
+            &cli_args.typesense_host,
+            &cli_args.typesense_port.to_string(),
+            "cache_hit_ratio",
+        ])
+        .set(ts_stats.cache_hit_ratio);
 
     typesense_stats
         .with_label_values(&[
@@ -303,6 +304,7 @@ pub(crate) async fn generate_metrics(
         ])
         .set(ts_stats.write_requests_per_second);
 
+    // Per-endpoint latency metrics
     let typesense_stats_latency_ms = register_gauge_vec_with_registry!(
         "typesense_stats_latency_ms",
         "Each endpoint latency in ms from stats api",
@@ -313,11 +315,12 @@ pub(crate) async fn generate_metrics(
 
     let typesense_stats_latency_ms_by_collection = register_gauge_vec_with_registry!(
         "typesense_stats_latency_ms_by_collection",
-        "Each endpoint latency in ms from stats api",
+        "Collection endpoint latency in ms from stats api",
         &["host", "port", "key", "method", "collection_name", "action"],
         registry
     )
     .unwrap();
+
     for (key, value) in ts_stats.latency_ms.iter() {
         typesense_stats_latency_ms
             .with_label_values(&[
@@ -327,29 +330,23 @@ pub(crate) async fn generate_metrics(
             ])
             .set(value.to_string().parse::<f64>().unwrap_or(0.0));
 
-        match parse_collection_action_line(key) {
-            Some((method, collection_name, action)) => {
-                println!("Method: {}", method);
-                println!("Collection Name: {}", collection_name);
-                println!("Action: {}", action);
-
-                typesense_stats_latency_ms_by_collection
-                    .with_label_values(&[
-                        &cli_args.typesense_host,
-                        &cli_args.typesense_port.to_string(),
-                        key,
-                        method.as_str(),
-                        collection_name.as_str(),
-                        action.as_str(),
-                    ])
-                    .set(value.to_string().parse::<f64>().unwrap_or(0.0));
-            }
-            None => {
-                println!("No match found");
-            }
+        // Only parse collection metrics for actual collection endpoints
+        if let Some((method, collection_name, action)) = parse_collection_action_line(key) {
+            typesense_stats_latency_ms_by_collection
+                .with_label_values(&[
+                    &cli_args.typesense_host,
+                    &cli_args.typesense_port.to_string(),
+                    key,
+                    method.as_str(),
+                    collection_name.as_str(),
+                    action.as_str(),
+                ])
+                .set(value.to_string().parse::<f64>().unwrap_or(0.0));
         }
+        // No else branch - silently skip non-collection endpoints
     }
 
+    // Per-endpoint request rate metrics
     let typesense_stats_requests_per_second = register_gauge_vec_with_registry!(
         "typesense_stats_requests_per_second",
         "Each endpoint rps from stats api",
@@ -360,7 +357,7 @@ pub(crate) async fn generate_metrics(
 
     let typesense_stats_requests_per_second_by_collection = register_gauge_vec_with_registry!(
         "typesense_stats_requests_per_second_by_collection",
-        "Each endpoint rps from stats api",
+        "Collection endpoint rps from stats api",
         &["host", "port", "key", "method", "collection_name", "action"],
         registry
     )
@@ -375,39 +372,70 @@ pub(crate) async fn generate_metrics(
             ])
             .set(value.to_string().parse::<f64>().unwrap_or(0.0));
 
-        match parse_collection_action_line(key) {
-            Some((method, collection_name, action)) => {
-                // println!("Method: {}", method);
-                // println!("Collection Name: {}", collection_name);
-                // println!("Action: {}", action);
-
-                typesense_stats_requests_per_second_by_collection
-                    .with_label_values(&[
-                        &cli_args.typesense_host,
-                        &cli_args.typesense_port.to_string(),
-                        key,
-                        method.as_str(),
-                        collection_name.as_str(),
-                        action.as_str(),
-                    ])
-                    .set(value.to_string().parse::<f64>().unwrap_or(0.0));
-            }
-            None => {
-                // println!("No match found");
-            }
+        // Only parse collection metrics for actual collection endpoints
+        if let Some((method, collection_name, action)) = parse_collection_action_line(key) {
+            typesense_stats_requests_per_second_by_collection
+                .with_label_values(&[
+                    &cli_args.typesense_host,
+                    &cli_args.typesense_port.to_string(),
+                    key,
+                    method.as_str(),
+                    collection_name.as_str(),
+                    action.as_str(),
+                ])
+                .set(value.to_string().parse::<f64>().unwrap_or(0.0));
         }
+        // No else branch - silently skip non-collection endpoints
     }
 
+    // Health status metric
+    let typesense_health = register_gauge_vec_with_registry!(
+        "typesense_health",
+        "Health status of Typesense instance (1 = healthy, 0 = unhealthy)",
+        &["host", "port"],
+        registry
+    )
+    .unwrap();
+
+    typesense_health
+        .with_label_values(&[
+            &cli_args.typesense_host,
+            &cli_args.typesense_port.to_string(),
+        ])
+        .set(if ts_health.ok { 1.0 } else { 0.0 });
+
+    // Raft state metric (for HA deployments)
+    let typesense_raft_state = register_gauge_vec_with_registry!(
+        "typesense_raft_state",
+        "Raft state of Typesense node (1 = leader, 4 = follower, 0 = other)",
+        &["host", "port"],
+        registry
+    )
+    .unwrap();
+
+    let state_value = match ts_debug.state {
+        1 => 1.0,
+        4 => 4.0,
+        _ => 0.0,
+    };
+
+    typesense_raft_state
+        .with_label_values(&[
+            &cli_args.typesense_host,
+            &cli_args.typesense_port.to_string(),
+        ])
+        .set(state_value);
+
+    // Encode and return
     let encoder = TextEncoder::new();
     let metric_families = registry.gather();
     let mut buffer = Vec::new();
     encoder.encode(&metric_families, &mut buffer).unwrap();
 
-    let metric_line = String::from_utf8(buffer).unwrap();
-
-    return metric_line;
+    String::from_utf8(buffer).unwrap()
 }
 
+/// Parse collection action endpoints like "GET /collections/products/documents/search"
 fn parse_collection_action_line(input: &str) -> Option<(String, String, String)> {
     let pattern = r"(\w+)\s+/collections/([^/]+)/([^/]+/[^/]+)";
     let re = Regex::new(pattern).unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,12 +3,16 @@ use std::sync::Arc;
 use crate::prometheus_exp;
 use crate::{
     cli::CliArgs,
-    typesense::{metrics::get_typesense_metrics, stats::get_typesense_stats},
+    typesense::{
+        stats::get_typesense_stats,
+        metrics::get_typesense_metrics,
+        health::get_typesense_health,
+        debug::get_typesense_debug,
+    },
 };
 
 use axum::extract::State;
 use axum::{routing::get, Router};
-use futures::future;
 use tokio::signal;
 
 pub(crate) async fn start_metrics_server(args: CliArgs) {
@@ -59,18 +63,19 @@ async fn root() -> &'static str {
 }
 
 async fn metrics_route_handler(State(args): State<Arc<CliArgs>>) -> String {
-    let (metrics_data, stats_data) = future::join(
+    let (metrics_data, stats_data, health_data, debug_data) = tokio::join!(
         get_typesense_metrics(args.clone()),
         get_typesense_stats(args.clone()),
-    )
-    .await;
+        get_typesense_health(args.clone()),
+        get_typesense_debug(args.clone()),
+    );
 
-    let promdata = prometheus_exp::generate_metrics(
+    prometheus_exp::generate_metrics(
         metrics_data.unwrap().clone(),
         stats_data.unwrap().clone(),
+        health_data.unwrap().clone(),
+        debug_data.unwrap().clone(),
         args.clone(),
     )
-    .await;
-
-    return promdata;
+    .await
 }

--- a/src/typesense/debug.rs
+++ b/src/typesense/debug.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::{cli::CliArgs, typesense::models::typesense_stats_model::TypesenseStats};
+use crate::{cli::CliArgs, typesense::models::typesense_debug_model::TypesenseDebug};
 use axum::Error;
 
-pub async fn get_typesense_stats(args: Arc<CliArgs>) -> Result<TypesenseStats, Error> {
-    let mut stats_data: TypesenseStats = TypesenseStats::default();
+pub async fn get_typesense_debug(args: Arc<CliArgs>) -> Result<TypesenseDebug, Error> {
+    let mut debug_data: TypesenseDebug = TypesenseDebug::default();
 
     let mut client_builder = reqwest::Client::builder();
     if args.typesense_timeout >= 0 {
@@ -14,39 +14,43 @@ pub async fn get_typesense_stats(args: Arc<CliArgs>) -> Result<TypesenseStats, E
     let client = client_builder.build().unwrap();
 
     let url = format!(
-        "{}://{}:{}/stats.json",
+        "{}://{}:{}/debug",
         args.typesense_protocol, args.typesense_host, args.typesense_port
     );
 
     let res = match client
         .get(url)
-        .header("X-TYPESENSE-API-KEY", args.typesense_api_key.to_string())
+        .header("X-TYPESENSE-API-KEY", format!("{}", args.typesense_api_key))
         .send()
         .await
     {
         Ok(res) => res,
         Err(e) => {
-            println!("Stats endpoint: request failed (timeout/connection error): {:?}", e);
-            return Ok(stats_data);
+            println!("Debug endpoint: request failed (timeout/connection error): {:?}", e);
+            return Ok(debug_data);
         }
     };
 
     match res.status() {
         reqwest::StatusCode::OK => {
-            match res.json::<TypesenseStats>().await {
+            match res.json::<TypesenseDebug>().await {
                 Ok(parsed) => {
-                    stats_data = parsed;
+                    debug_data = parsed;
                 }
-                Err(_) => println!("Hm, the response didn't match the shape we expected."),
+                Err(er) => println!(
+                    "Hm, the response didn't match the shape we expected. {:?}",
+                    er
+                ),
             };
         }
         reqwest::StatusCode::UNAUTHORIZED => {
-            println!("Need to grab a new token");
+            println!("Debug endpoint: Need to grab a new token");
         }
         _ => {
             println!("Uh oh! Something unexpected happened.");
         }
     };
 
-    Ok(stats_data)
+    Ok(debug_data)
 }
+

--- a/src/typesense/health.rs
+++ b/src/typesense/health.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::{cli::CliArgs, typesense::models::typesense_stats_model::TypesenseStats};
+use crate::{cli::CliArgs, typesense::models::typesense_health_model::TypesenseHealth};
 use axum::Error;
 
-pub async fn get_typesense_stats(args: Arc<CliArgs>) -> Result<TypesenseStats, Error> {
-    let mut stats_data: TypesenseStats = TypesenseStats::default();
+pub async fn get_typesense_health(args: Arc<CliArgs>) -> Result<TypesenseHealth, Error> {
+    let mut health_data: TypesenseHealth = TypesenseHealth::default();
 
     let mut client_builder = reqwest::Client::builder();
     if args.typesense_timeout >= 0 {
@@ -14,39 +14,39 @@ pub async fn get_typesense_stats(args: Arc<CliArgs>) -> Result<TypesenseStats, E
     let client = client_builder.build().unwrap();
 
     let url = format!(
-        "{}://{}:{}/stats.json",
+        "{}://{}:{}/health",
         args.typesense_protocol, args.typesense_host, args.typesense_port
     );
 
     let res = match client
         .get(url)
-        .header("X-TYPESENSE-API-KEY", args.typesense_api_key.to_string())
         .send()
         .await
     {
         Ok(res) => res,
         Err(e) => {
-            println!("Stats endpoint: request failed (timeout/connection error): {:?}", e);
-            return Ok(stats_data);
+            println!("Health endpoint: request failed (timeout/connection error): {:?}", e);
+            return Ok(health_data);
         }
     };
 
     match res.status() {
         reqwest::StatusCode::OK => {
-            match res.json::<TypesenseStats>().await {
+            match res.json::<TypesenseHealth>().await {
                 Ok(parsed) => {
-                    stats_data = parsed;
+                    health_data = parsed;
                 }
-                Err(_) => println!("Hm, the response didn't match the shape we expected."),
+                Err(er) => println!(
+                    "Hm, the response didn't match the shape we expected. {:?}",
+                    er
+                ),
             };
-        }
-        reqwest::StatusCode::UNAUTHORIZED => {
-            println!("Need to grab a new token");
         }
         _ => {
             println!("Uh oh! Something unexpected happened.");
         }
     };
 
-    Ok(stats_data)
+    Ok(health_data)
 }
+

--- a/src/typesense/metrics.rs
+++ b/src/typesense/metrics.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::{cli::CliArgs, typesense::models::typesense_metrics_model::TypesenseMetrics};
 use axum::Error;
@@ -6,19 +7,29 @@ use axum::Error;
 pub async fn get_typesense_metrics(args: Arc<CliArgs>) -> Result<TypesenseMetrics, Error> {
     let mut stats_data: TypesenseMetrics = TypesenseMetrics::default();
 
-    let client = reqwest::Client::new();
+    let mut client_builder = reqwest::Client::builder();
+    if args.typesense_timeout >= 0 {
+        client_builder = client_builder.timeout(Duration::from_secs(args.typesense_timeout as u64));
+    }
+    let client = client_builder.build().unwrap();
 
     let url: String = format!(
         "{}://{}:{}/metrics.json",
         args.typesense_protocol, args.typesense_host, args.typesense_port
     );
 
-    let res = client
+    let res = match client
         .get(url)
-        .header("X-TYPESENSE-API-KEY", format!("{}", args.typesense_api_key))
+        .header("X-TYPESENSE-API-KEY", args.typesense_api_key.to_string())
         .send()
         .await
-        .unwrap();
+    {
+        Ok(res) => res,
+        Err(e) => {
+            println!("Metrics endpoint: request failed (timeout/connection error): {:?}", e);
+            return Ok(stats_data);
+        }
+    };
 
     match res.status() {
         reqwest::StatusCode::OK => {
@@ -36,7 +47,7 @@ pub async fn get_typesense_metrics(args: Arc<CliArgs>) -> Result<TypesenseMetric
             println!("Need to grab a new token");
         }
         _ => {
-            panic!("Uh oh! Something unexpected happened.");
+            println!("Uh oh! Something unexpected happened.");
         }
     };
 

--- a/src/typesense/mod.rs
+++ b/src/typesense/mod.rs
@@ -1,3 +1,5 @@
 pub mod metrics;
-pub mod stats;
 pub mod models;
+pub mod stats;
+pub mod health;
+pub mod debug;

--- a/src/typesense/models/mod.rs
+++ b/src/typesense/models/mod.rs
@@ -1,2 +1,4 @@
 pub mod typesense_metrics_model;
 pub mod typesense_stats_model;
+pub mod typesense_health_model;
+pub mod typesense_debug_model;

--- a/src/typesense/models/typesense_debug_model.rs
+++ b/src/typesense/models/typesense_debug_model.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TypesenseDebug {
+    pub version: String,
+    pub state: i32,
+}
+
+impl Default for TypesenseDebug {
+    fn default() -> TypesenseDebug {
+        TypesenseDebug {
+            version: String::new(),
+            state: 0,
+        }
+    }
+}
+

--- a/src/typesense/models/typesense_health_model.rs
+++ b/src/typesense/models/typesense_health_model.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TypesenseHealth {
+    pub ok: bool,
+    #[serde(default)]
+    pub resource_error: Option<String>,
+}
+
+impl Default for TypesenseHealth {
+    fn default() -> TypesenseHealth {
+        TypesenseHealth {
+            ok: false,
+            resource_error: None,
+        }
+    }
+}
+

--- a/src/typesense/models/typesense_metrics_model.rs
+++ b/src/typesense/models/typesense_metrics_model.rs
@@ -1,54 +1,67 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
+/// Typesense metrics from /metrics.json endpoint
+/// Uses flatten to capture all CPU metrics dynamically (system_cpu1_active_percentage through system_cpuN_active_percentage)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TypesenseMetrics {
-    pub system_cpu1_active_percentage: String,
-    #[serde(default = "system_cpu2_active_percentage_default")]
-    pub system_cpu2_active_percentage: String,
-     #[serde(default = "system_cpu3_active_percentage_default")]
-    pub system_cpu3_active_percentage: String,
-     #[serde(default = "system_cpu4_active_percentage_default")]
-    pub system_cpu4_active_percentage: String,
-     #[serde(default = "system_cpu5_active_percentage_default")]
-    pub system_cpu5_active_percentage: String,
-     #[serde(default = "system_cpu6_active_percentage_default")]
-    pub system_cpu6_active_percentage: String,
-     #[serde(default = "system_cpu7_active_percentage_default")]
-    pub system_cpu7_active_percentage: String,
-     #[serde(default = "system_cpu8_active_percentage_default")]
-    pub system_cpu8_active_percentage: String,
+    // Aggregate CPU (always present)
+    #[serde(default = "default_zero_string")]
     pub system_cpu_active_percentage: String,
+
+    // Disk metrics
+    #[serde(default = "default_zero_string")]
     pub system_disk_total_bytes: String,
+    #[serde(default = "default_zero_string")]
     pub system_disk_used_bytes: String,
+
+    // Memory metrics
+    #[serde(default = "default_zero_string")]
     pub system_memory_total_bytes: String,
+    #[serde(default = "default_zero_string")]
     pub system_memory_used_bytes: String,
+    #[serde(default = "default_zero_string")]
+    pub system_memory_total_swap_bytes: String,
+    #[serde(default = "default_zero_string")]
+    pub system_memory_used_swap_bytes: String,
+
+    // Network metrics
+    #[serde(default = "default_zero_string")]
     pub system_network_received_bytes: String,
+    #[serde(default = "default_zero_string")]
     pub system_network_sent_bytes: String,
+
+    // Typesense memory metrics
+    #[serde(default = "default_zero_string")]
     pub typesense_memory_active_bytes: String,
+    #[serde(default = "default_zero_string")]
     pub typesense_memory_allocated_bytes: String,
+    #[serde(default = "default_zero_string")]
     pub typesense_memory_fragmentation_ratio: String,
+    #[serde(default = "default_zero_string")]
     pub typesense_memory_mapped_bytes: String,
+    #[serde(default = "default_zero_string")]
     pub typesense_memory_metadata_bytes: String,
+    #[serde(default = "default_zero_string")]
     pub typesense_memory_resident_bytes: String,
+    #[serde(default = "default_zero_string")]
     pub typesense_memory_retained_bytes: String,
+
+    // Capture all other fields dynamically (including system_cpu1-N_active_percentage)
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 impl Default for TypesenseMetrics {
     fn default() -> TypesenseMetrics {
         TypesenseMetrics {
-            system_cpu1_active_percentage: "0".to_string(),
-            system_cpu2_active_percentage: "0".to_string(),
-            system_cpu3_active_percentage: "0".to_string(),
-            system_cpu4_active_percentage: "0".to_string(),
-            system_cpu5_active_percentage: "0".to_string(),
-            system_cpu6_active_percentage: "0".to_string(),
-            system_cpu7_active_percentage: "0".to_string(),
-            system_cpu8_active_percentage: "0".to_string(),
             system_cpu_active_percentage: "0".to_string(),
             system_disk_total_bytes: "0".to_string(),
             system_disk_used_bytes: "0".to_string(),
             system_memory_total_bytes: "0".to_string(),
             system_memory_used_bytes: "0".to_string(),
+            system_memory_total_swap_bytes: "0".to_string(),
+            system_memory_used_swap_bytes: "0".to_string(),
             system_network_received_bytes: "0".to_string(),
             system_network_sent_bytes: "0".to_string(),
             typesense_memory_active_bytes: "0".to_string(),
@@ -58,39 +71,46 @@ impl Default for TypesenseMetrics {
             typesense_memory_metadata_bytes: "0".to_string(),
             typesense_memory_resident_bytes: "0".to_string(),
             typesense_memory_retained_bytes: "0".to_string(),
+            extra: HashMap::new(),
         }
     }
 }
 
-fn system_cpu2_active_percentage_default() -> String{
-  "0".to_string()
+fn default_zero_string() -> String {
+    "0".to_string()
 }
 
-fn system_cpu3_active_percentage_default() -> String{
-  "0".to_string()
+impl TypesenseMetrics {
+    /// Returns all CPU percentage metrics (system_cpu1_active_percentage, system_cpu2_active_percentage, etc.)
+    pub fn get_cpu_percentages(&self) -> Vec<(String, f64)> {
+        let mut cpus = Vec::new();
+
+        for (key, value) in &self.extra {
+            if key.starts_with("system_cpu") && key.ends_with("_active_percentage") && key != "system_cpu_active_percentage" {
+                let val_str = match value {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Number(n) => n.to_string(),
+                    _ => "0".to_string(),
+                };
+                let val: f64 = val_str.parse().unwrap_or(0.0);
+                cpus.push((key.clone(), val));
+            }
+        }
+
+        // Sort by CPU number for consistent output
+        cpus.sort_by(|a, b| {
+            let num_a = extract_cpu_number(&a.0).unwrap_or(0);
+            let num_b = extract_cpu_number(&b.0).unwrap_or(0);
+            num_a.cmp(&num_b)
+        });
+
+        cpus
+    }
 }
 
-fn system_cpu4_active_percentage_default() -> String{
-  "0".to_string()
+/// Extract the CPU number from a metric name like "system_cpu12_active_percentage"
+fn extract_cpu_number(key: &str) -> Option<u32> {
+    let stripped = key.strip_prefix("system_cpu")?;
+    let num_str = stripped.strip_suffix("_active_percentage")?;
+    num_str.parse().ok()
 }
-
-
-fn system_cpu5_active_percentage_default() -> String{
-  "0".to_string()
-}
-
-
-fn system_cpu6_active_percentage_default() -> String{
-  "0".to_string()
-}
-
-
-fn system_cpu7_active_percentage_default() -> String{
-  "0".to_string()
-}
-
-
-fn system_cpu8_active_percentage_default() -> String{
-  "0".to_string()
-}
-

--- a/src/typesense/models/typesense_stats_model.rs
+++ b/src/typesense/models/typesense_stats_model.rs
@@ -1,44 +1,35 @@
-
-
-use serde_json::Value;
+use serde::{Deserialize, Serialize};
 use serde_json::Map;
-use serde::{Serialize, Deserialize};
+use serde_json::Value;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct TypesenseStats {
+    #[serde(default)]
+    pub cache_hit_ratio: f64,
+    #[serde(default)]
     pub delete_latency_ms: f64,
+    #[serde(default)]
     pub delete_requests_per_second: f64,
+    #[serde(default)]
     pub import_latency_ms: f64,
+    #[serde(default)]
     pub import_requests_per_second: f64,
+    #[serde(default)]
     pub latency_ms: Map<String, Value>,
+    #[serde(default)]
     pub overloaded_requests_per_second: f64,
+    #[serde(default)]
     pub pending_write_batches: f64,
+    #[serde(default)]
     pub requests_per_second: Map<String, Value>,
+    #[serde(default)]
     pub search_latency_ms: f64,
+    #[serde(default)]
     pub search_requests_per_second: f64,
+    #[serde(default)]
     pub total_requests_per_second: f64,
+    #[serde(default)]
     pub write_latency_ms: f64,
+    #[serde(default)]
     pub write_requests_per_second: f64,
-}
-
-
-
-impl Default for TypesenseStats {
-    fn default() -> TypesenseStats {
-        TypesenseStats {
-            delete_latency_ms: 0.0,
-delete_requests_per_second: 0.0,
-import_latency_ms: 0.0,
-import_requests_per_second: 0.0,
-latency_ms: Map::new(),
-overloaded_requests_per_second: 0.0,
-pending_write_batches: 0.0,
-requests_per_second: Map::new(),
-search_latency_ms: 0.0,
-search_requests_per_second: 0.0,
-total_requests_per_second: 0.0,
-write_latency_ms: 0.0,
-write_requests_per_second: 0.0,
-        }
-    }
 }


### PR DESCRIPTION
This PR consolidates and builds upon existing community contributions while adding additional improvements for better Typesense monitoring.

## Credits

This PR includes work from the following outstanding pull requests:

- **PR #11** by @weriomat  - Makes CPU fields optional to prevent parsing failures on systems with varying CPU counts
- **PR #13** by @andriimredocly - Adds health endpoint and raft state metrics for HA deployment monitoring

Thank you to the original contributors for their work! If you'd prefer to merge those PRs first to preserve individual attribution, I'm happy to rebase this PR afterward to show only my additional changes.

## Summary of All Changes

### From PR #11: Optional CPU Fields
- CPU percentage fields are now optional with `#[serde(default)]`
- Prevents JSON parsing failures when Typesense returns fewer CPU fields than expected

### From PR #13: Health and Raft Metrics
- Added `/health` endpoint monitoring (`typesense_health` metric)
- Added `/debug` endpoint for raft state (`typesense_raft_state` metric)
- Useful for monitoring Typesense HA cluster leader/follower status

### Additional Improvements in This PR

#### Dynamic CPU Handling
- Replaced hardcoded CPU fields (cpu1-cpu8) with dynamic discovery using `#[serde(flatten)]`
- Now supports any number of CPUs (tested with 32 CPUs)
- Automatically exports all `system_cpuN_active_percentage` metrics regardless of CPU count

#### Swap Memory Metrics
- Added `system_memory_total_swap_bytes` metric
- Added `system_memory_used_swap_bytes` metric
- Useful for monitoring memory pressure on the Typesense host

#### Cache Hit Ratio
- Added `cache_hit_ratio` metric from the stats endpoint
- Important for monitoring search performance and cache efficiency

#### Reduced Log Noise
- Removed verbose "No match found" println statements when parsing non-collection endpoints
- These messages were logged on every scrape for endpoints like `GET /health`, `GET /metrics.json`
- Non-collection endpoints are now silently skipped as expected

## Backward Compatibility

All changes are backward compatible with older Typesense versions:
- Fields use `#[serde(default)]` so missing fields default to 0
- Unknown fields are captured via `#[serde(flatten)]` without causing parse errors
- Value parsing uses `.unwrap_or(0.0)` for graceful fallback

## Testing

Tested against Typesense v30.0 with:
- 32 CPU cores (all metrics exported correctly)
- Single-node deployment (raft_state = 1/leader)
- Health endpoint returning `{"ok": true}`

---

## Checklist

- [x] Dynamic CPU support for any number of cores
- [x] Health status metric
- [x] Raft state metric for HA monitoring
- [x] Swap memory metrics
- [x] Cache hit ratio metric
- [x] Backward compatible with older Typesense versions
- [x] Reduced log verbosity